### PR TITLE
Add optional documentation to declaration items in (decl) form.

### DIFF
--- a/src/c-mera/traverser.lisp
+++ b/src/c-mera/traverser.lisp
@@ -27,20 +27,23 @@
   (declare (ignore level)))
 
 ;;; Inserts a single proxy-node in the AST.
-(defmacro make-proxy (slot node-type &key (node-name 'item) (parent 'item))
+(defmacro make-proxy (slot node-type &key (node-name 'item) (parent 'item) for)
   "Add proxy nodes to slot. Note: all uses in c-mera and cm-c implicitly assue that the node is called ITEM."
   (let ((val (gensym)))
     `(if (or (eql (find-class 'nodelist) (class-of (slot-value ,node-name ',slot))))
   	 (let ((,val (slot-value (slot-value ,node-name ',slot) 'nodes)))
   	   (setf (slot-value (slot-value ,node-name ',slot) 'nodes)
   		 (loop for i in ,val collect
-  		      (make-instance ,node-type
-				     :parent ,parent
-  				     :proxy-subnode i
-  				     :values '()
-  				     :subnodes '(proxy-subnode)))))
+		       (if (or (not ,for) (and ,for (funcall ,for i)))
+			   (make-instance ,node-type
+					  :parent ,parent
+					  :proxy-subnode i
+					  :values '()
+					  :subnodes '(proxy-subnode))
+			   i))))
   	 (let ((,val (slot-value ,node-name ',slot)))
   	   (if ,val
+	       ;; todo
   	       (setf (slot-value ,node-name ',slot)
   		     (make-instance ,node-type
 				    :parent ,parent
@@ -63,7 +66,9 @@
   	   (let ((,node-list (slot-value (slot-value ,node-name ',slot) 'nodes)))
  	     (setf (slot-value (slot-value ,node-name ',slot) 'nodes)
   		   (loop for i in ,node-list collect
-  			(slot-value i 'proxy-subnode))))
+			 (if (equal (slot-value i 'subnodes) '(proxy-subnode))
+			     (slot-value i 'proxy-subnode)
+			     i))))
   	   (if ,val (setf (slot-value ,node-name ',slot)
   			  (slot-value ,val 'proxy-subnode)))))))
 

--- a/src/c-mera/traverser.lisp
+++ b/src/c-mera/traverser.lisp
@@ -28,12 +28,14 @@
 
 ;;; Inserts a single proxy-node in the AST.
 (defmacro make-proxy (slot node-type &key (node-name 'item) (parent 'item) for)
-  "Add proxy nodes to slot. Note: all uses in c-mera and cm-c implicitly assue that the node is called ITEM."
+  "Add proxy nodes to slot.
+   Note: all uses in c-mera and cm-c implicitly assue that the node is called ITEM.
+   FOR is used on slots that hold lists of nodes to filter where to insert a proxy node."
   (let ((val (gensym)))
     `(if (or (eql (find-class 'nodelist) (class-of (slot-value ,node-name ',slot))))
-  	 (let ((,val (slot-value (slot-value ,node-name ',slot) 'nodes)))
-  	   (setf (slot-value (slot-value ,node-name ',slot) 'nodes)
-  		 (loop for i in ,val collect
+	 (let ((,val (slot-value (slot-value ,node-name ',slot) 'nodes)))
+	   (setf (slot-value (slot-value ,node-name ',slot) 'nodes)
+		 (loop for i in ,val collect
 		       (if (or (not ,for) (and ,for (funcall ,for i)))
 			   (make-instance ,node-type
 					  :parent ,parent
@@ -41,21 +43,20 @@
 					  :values '()
 					  :subnodes '(proxy-subnode))
 			   i))))
-  	 (let ((,val (slot-value ,node-name ',slot)))
-  	   (if ,val
-	       ;; todo
-  	       (setf (slot-value ,node-name ',slot)
-  		     (make-instance ,node-type
+	 (let ((,val (slot-value ,node-name ',slot)))
+	   (if ,val
+	       (setf (slot-value ,node-name ',slot)
+		     (make-instance ,node-type
 				    :parent ,parent
-  				    :proxy-subnode ,val
-  				    :values '()
-  				    :subnodes '(proxy-subnode)))
-  	       (setf (slot-value ,node-name ',slot)
-  	       	     (make-instance ,node-type
+				    :proxy-subnode ,val
+				    :values '()
+				    :subnodes '(proxy-subnode)))
+	       (setf (slot-value ,node-name ',slot)
+		     (make-instance ,node-type
 				    :parent ,parent
-  	       			    :proxy-subnode nil
-  	       			    :values '()
-  	       			    :subnodes '(proxy-subnode))))))))
+				    :proxy-subnode nil
+				    :values '()
+				    :subnodes '(proxy-subnode))))))))
 
 ;;; Deletes a single proxy-node from the AST.
 (defmacro del-proxy (slot &key (node-name 'item))
@@ -63,14 +64,14 @@
   (let ((val (gensym)) (node-list (gensym)))
     `(let ((,val (slot-value ,node-name ',slot)))
        (if (eql (find-class 'nodelist) (class-of (slot-value ,node-name ',slot)))
-  	   (let ((,node-list (slot-value (slot-value ,node-name ',slot) 'nodes)))
- 	     (setf (slot-value (slot-value ,node-name ',slot) 'nodes)
-  		   (loop for i in ,node-list collect
+	   (let ((,node-list (slot-value (slot-value ,node-name ',slot) 'nodes)))
+	     (setf (slot-value (slot-value ,node-name ',slot) 'nodes)
+		   (loop for i in ,node-list collect
 			 (if (equal (slot-value i 'subnodes) '(proxy-subnode))
 			     (slot-value i 'proxy-subnode)
 			     i))))
-  	   (if ,val (setf (slot-value ,node-name ',slot)
-  			  (slot-value ,val 'proxy-subnode)))))))
+	   (if ,val (setf (slot-value ,node-name ',slot)
+			  (slot-value ,val 'proxy-subnode)))))))
 
 ;;; Defines proxy nodes for local usage.
 ;;; These nodes can be used with 'add-proxy', 'del-proxy',

--- a/src/c-mera/utils.lisp
+++ b/src/c-mera/utils.lisp
@@ -81,18 +81,6 @@
 			    `(make-node-function (quoty ,i)))))))))
 		    ;`(make-node ,i)))))))
 
-;;(defmacro make-nodelist (items &key (prepend nil) (quoty nil))
-;;  "Build general or specific nodelist."
-;;  (let ((prepend (if (listp prepend) prepend `(,prepend))))
-;;    `(nodelist
-;;      (list ,@(loop for i in items collect
-;;		(if prepend
-;;		    (if quoty
-;;			`(,@prepend (quoty ,i))
-;;			`(,@prepend ,i))
-;;		    `(make-node-function (quoty ,i))))))))
-;;		    ;`(make-node ,i)))))))
-
 ;;; the atom lists
 ;(defmacro make-node (item)
 ;  "Try to identify and make node object"

--- a/src/c-mera/utils.lisp
+++ b/src/c-mera/utils.lisp
@@ -72,13 +72,13 @@
   "Build general or specific nodelist."
   (let ((prepend (if (listp prepend) prepend `(,prepend))))
     `(nodelist
-      (delete nil (nconc ,@(loop for i in items collect
+      (nconc ,@(loop for i in items collect
 		     `(multiple-value-list
 		       ,(if prepend
 			    (if quoty
 				`(,@prepend (quoty ,i))
 				`(,@prepend ,i))
-			    `(make-node-function (quoty ,i))))))))))
+			    `(make-node-function (quoty ,i)))))))))
 		    ;`(make-node ,i)))))))
 
 ;;(defmacro make-nodelist (items &key (prepend nil) (quoty nil))

--- a/src/c-mera/utils.lisp
+++ b/src/c-mera/utils.lisp
@@ -72,13 +72,26 @@
   "Build general or specific nodelist."
   (let ((prepend (if (listp prepend) prepend `(,prepend))))
     `(nodelist
-      (list ,@(loop for i in items collect
-		(if prepend
-		    (if quoty
-			`(,@prepend (quoty ,i))
-			`(,@prepend ,i))
-		    `(make-node-function (quoty ,i))))))))
+      (delete nil (nconc ,@(loop for i in items collect
+		     `(multiple-value-list
+		       ,(if prepend
+			    (if quoty
+				`(,@prepend (quoty ,i))
+				`(,@prepend ,i))
+			    `(make-node-function (quoty ,i))))))))))
 		    ;`(make-node ,i)))))))
+
+;;(defmacro make-nodelist (items &key (prepend nil) (quoty nil))
+;;  "Build general or specific nodelist."
+;;  (let ((prepend (if (listp prepend) prepend `(,prepend))))
+;;    `(nodelist
+;;      (list ,@(loop for i in items collect
+;;		(if prepend
+;;		    (if quoty
+;;			`(,@prepend (quoty ,i))
+;;			`(,@prepend ,i))
+;;		    `(make-node-function (quoty ,i))))))))
+;;		    ;`(make-node ,i)))))))
 
 ;;; the atom lists
 ;(defmacro make-node (item)

--- a/src/c/nodes.lisp
+++ b/src/c/nodes.lisp
@@ -17,7 +17,7 @@
 
 ;; variable declaration
 (defnode declaration-list (braces) (bindings body))
-(defnode declaration-item () (specifier type identifier value comment))
+(defnode declaration-item () (specifier type identifier value))
 (defnode declaration-value () (value))
 
 ;; essential bulding blocks

--- a/src/c/nodes.lisp
+++ b/src/c/nodes.lisp
@@ -17,7 +17,7 @@
 
 ;; variable declaration
 (defnode declaration-list (braces) (bindings body))
-(defnode declaration-item () (specifier type identifier value))
+(defnode declaration-item () (specifier type identifier value comment))
 (defnode declaration-value () (value))
 
 ;; essential bulding blocks

--- a/src/c/pretty.lisp
+++ b/src/c/pretty.lisp
@@ -235,7 +235,11 @@
       (format stream "~&~a" indent))
 
     (defproxyprint :after declaration-item
-      (format stream ";"))))
+      (format stream ";")
+      (let ((comment (slot-value (node-slot proxy-subnode) 'comment)))
+	(when comment
+	  (format stream "~c" #\tab)
+	  (traverser c-mera::pp comment (1+ c-mera::level)))))))
 
 ;;; Declaration item
 ;;; Handle declaration assignment.
@@ -708,10 +712,11 @@
 ;;; Comment
 (with-pp
   (defprettymethod :self comment
-    (when (node-slot linebreak)
-      (format stream "~&~a" indent))
-    (format stream "~a" (node-slot chars))
-    (format stream "~a"  (node-slot comment))))
+    (unless (eq (top-info) 'declaration-item) ;; don't print comments of declaration items, they are handled after the #\; was emitted
+      (when (node-slot linebreak)
+	(format stream "~&~a" indent))
+      (format stream "~a" (node-slot chars))
+      (format stream "~a" (node-slot comment)))))
     
     ;(format stream "~&~a" indent)))
 

--- a/src/c/pretty.lisp
+++ b/src/c/pretty.lisp
@@ -236,12 +236,7 @@
       (format stream "~&~a" indent))
 
     (defproxyprint :after declaration-item
-      (format stream ";")
-      ;;(let ((comment (slot-value (node-slot proxy-subnode) 'comment)))
-      ;;	(when comment
-      ;;	  (format stream "~c" #\tab)
-      ;;	  (traverser c-mera::pp comment (1+ c-mera::level))))
-      )))
+      (format stream ";"))))
 
 ;;; Declaration item
 ;;; Handle declaration assignment.

--- a/src/c/pretty.lisp
+++ b/src/c/pretty.lisp
@@ -216,7 +216,8 @@
   (with-proxynodes (declaration-item)
 
     (defprettymethod :before declaration-list
-      (make-proxy bindings declaration-item)
+      (make-proxy bindings declaration-item
+		  :for (lambda (n) (typep n 'declaration-item)))
       (push-info 'decl)
       (if (node-slot braces)
 	  (progn
@@ -236,10 +237,11 @@
 
     (defproxyprint :after declaration-item
       (format stream ";")
-      (let ((comment (slot-value (node-slot proxy-subnode) 'comment)))
-	(when comment
-	  (format stream "~c" #\tab)
-	  (traverser c-mera::pp comment (1+ c-mera::level)))))))
+      ;;(let ((comment (slot-value (node-slot proxy-subnode) 'comment)))
+      ;;	(when comment
+      ;;	  (format stream "~c" #\tab)
+      ;;	  (traverser c-mera::pp comment (1+ c-mera::level))))
+      )))
 
 ;;; Declaration item
 ;;; Handle declaration assignment.

--- a/src/c/syntax.lisp
+++ b/src/c/syntax.lisp
@@ -228,32 +228,24 @@
 (defmacro make-declaration-node (item)
   "Decompose declaration item and instantiate nodes"
   (if (eql item '&rest)
-    `(make-node '|...|)
-    (multiple-value-bind (specifier type id init comment) (decompose-declaration item)
-      `(values
-	(declaration-item
-	 ;; set specifiers
-	 ,(when specifier
-	    `(specifier
-	      (make-nodelist ,specifier)))
-	 ;; set type
-	 (type (make-node ,type))
-	 ;; set identifier
-	 (make-node ,id)
-	 ;; set value
-	 ,(if init
-	      `(declaration-value (make-node ,init))
-	      nil)
-	 ;; set comment
-	 ;;,(if comment
-	 ;;     `(comment "//" ,comment nil)
-	 ;;     nil)
-	 nil
-	 )
-	,(if comment
-	    `(comment "//" ,comment nil)
-	    nil)
-	))))
+      `(make-node '|...|)
+      (multiple-value-bind (specifier type id init comment) (decompose-declaration item)
+	`(values
+	  (declaration-item
+	   ;; set specifiers
+	   ,(when specifier
+	      `(specifier
+		(make-nodelist ,specifier)))
+	   ;; set type
+	   (type (make-node ,type))
+	   ;; set identifier
+	   (make-node ,id)
+	   ;; set value
+	   ,(if init
+		`(declaration-value (make-node ,init))
+		nil))
+	  ,@(if comment
+		`((comment "//" ,comment nil)))))))
  
 (defmacro decompose-type (item)
   "Decompose type like declaration but without name"

--- a/src/c/syntax.lisp
+++ b/src/c/syntax.lisp
@@ -263,9 +263,7 @@
     ;; enum init
     ,(when (second item)
 	   `(declaration-value
-	     (make-node ,(second item))))
-    ;; comment (not supported, yet)
-    nil))
+	     (make-node ,(second item))))))
 
 (c-syntax decl (bindings &body body)
   "Declare variables:

--- a/src/c/syntax.lisp
+++ b/src/c/syntax.lisp
@@ -201,17 +201,12 @@
 	       (and (symbolp symbol)
 		    (equal (symbol-name symbol) str)))))
 
-    (format t "~&---> ~a~%" item)
-    (format t "~&---> ~a~%" (penultimate item))
-    (format t "~&---> ~a~%" (symbolp (penultimate item)))
-
     ;; transparently remove comment from ITEM
     (multiple-value-bind (comment item)
 	(if (suffix-is "COMMENT" item)
 	    (values (first (last item)) (butlast item 2))
 	    (values nil item))
 
-      (format t "~&---> ~a / ~a~%" item comment)
       ;; check initialization
       (if (suffix-is "=" item)
 

--- a/src/c/syntax.lisp
+++ b/src/c/syntax.lisp
@@ -193,45 +193,65 @@
     ,linebreak))
 
 (defun decompose-declaration (item)
-  "Decompose declaration item into its SPECIFIERS, TYPE, NAME and INITIALIZER"
-  (if (let ((symbol (first (last (butlast item)))))
-	(and (symbolp symbol)
-	     (equal (symbol-name symbol) "=")))
+  "Decompose declaration item into its SPECIFIERS, TYPE, NAME, INITIALIZER, and, optionally, DOCUMENTATION"
+  (labels ((penultimate (list) ;; second-last item in LIST
+	     (first (last (butlast list))))
+	   (suffix-is (str list) ;; check if LIST ends with (... STR something)
+	     (let ((symbol (penultimate list)))
+	       (and (symbolp symbol)
+		    (equal (symbol-name symbol) str)))))
 
-      ;; decompose arg list with init
-      (let ((specifier (butlast item 4))
-	    (type+id+val (last item 4)))
-	(let ((type (first type+id+val))
-	      (id   (second type+id+val))
-	      (init (fourth type+id+val)))
-	  (values specifier type id init)))
+    (format t "~&---> ~a~%" item)
+    (format t "~&---> ~a~%" (penultimate item))
+    (format t "~&---> ~a~%" (symbolp (penultimate item)))
 
-      ;; decompose arg list without init
-      (let ((specifier (butlast item 2))
-	    (type+id (last item 2)))
-	(let ((type (first type+id))
-	      (id   (second type+id)))
-	  (values specifier type id nil)))))
+    ;; transparently remove comment from ITEM
+    (multiple-value-bind (comment item)
+	(if (suffix-is "COMMENT" item)
+	    (values (first (last item)) (butlast item 2))
+	    (values nil item))
+
+      (format t "~&---> ~a / ~a~%" item comment)
+      ;; check initialization
+      (if (suffix-is "=" item)
+
+	  ;; decompose arg list with init
+	  (let ((specifier (butlast item 4))
+		(type+id+val (last item 4)))
+	    (let ((type (first type+id+val))
+		  (id   (second type+id+val))
+		  (init (fourth type+id+val)))
+	      (values specifier type id init comment)))
+
+	  ;; decompose arg list without init
+	  (let ((specifier (butlast item 2))
+		(type+id (last item 2)))
+	    (let ((type (first type+id))
+		  (id   (second type+id)))
+	      (values specifier type id nil comment)))))))
 
 (defmacro make-declaration-node (item)
   "Decompose declaration item and instantiate nodes"
   (if (eql item '&rest)
     `(make-node '|...|)
-    (multiple-value-bind (specifier type id init) (decompose-declaration item)
+    (multiple-value-bind (specifier type id init comment) (decompose-declaration item)
       `(declaration-item
-        ;; set specifiers
-        ,(when specifier
-         `(specifier
-           (make-nodelist ,specifier)))
-        ;; set type
-        (type (make-node ,type))
-        ;; set identifier
-        (make-node ,id)
-        ;; set value
-        ,(if init 
-       `(declaration-value
-         (make-node ,init))
-       nil)))))
+	;; set specifiers
+	,(when specifier
+	   `(specifier
+	     (make-nodelist ,specifier)))
+	;; set type
+	(type (make-node ,type))
+	;; set identifier
+	(make-node ,id)
+	;; set value
+	,(if init
+	     `(declaration-value (make-node ,init))
+	     nil)
+	;; set comment
+	,(if comment
+	     `(comment "//" ,comment nil)
+	     nil)))))
  
 (defmacro decompose-type (item)
   "Decompose type like declaration but without name"
@@ -249,10 +269,13 @@
     ;; enum init
     ,(when (second item)
 	   `(declaration-value
-		 (make-node ,(second item))))))
+	     (make-node ,(second item))))
+    ;; comment (not supported, yet)
+    nil))
 
 (c-syntax decl (bindings &body body)
-  "Declare variables"
+  "Declare variables:
+   Each item in BINDINGS is expanded to a call of MAKE-DECLARATION-NODE using that item."
   `(declaration-list
     ;; braces t, adjusted later by traverser
     t

--- a/src/c/syntax.lisp
+++ b/src/c/syntax.lisp
@@ -230,23 +230,30 @@
   (if (eql item '&rest)
     `(make-node '|...|)
     (multiple-value-bind (specifier type id init comment) (decompose-declaration item)
-      `(declaration-item
-	;; set specifiers
-	,(when specifier
-	   `(specifier
-	     (make-nodelist ,specifier)))
-	;; set type
-	(type (make-node ,type))
-	;; set identifier
-	(make-node ,id)
-	;; set value
-	,(if init
-	     `(declaration-value (make-node ,init))
-	     nil)
-	;; set comment
+      `(values
+	(declaration-item
+	 ;; set specifiers
+	 ,(when specifier
+	    `(specifier
+	      (make-nodelist ,specifier)))
+	 ;; set type
+	 (type (make-node ,type))
+	 ;; set identifier
+	 (make-node ,id)
+	 ;; set value
+	 ,(if init
+	      `(declaration-value (make-node ,init))
+	      nil)
+	 ;; set comment
+	 ;;,(if comment
+	 ;;     `(comment "//" ,comment nil)
+	 ;;     nil)
+	 nil
+	 )
 	,(if comment
-	     `(comment "//" ,comment nil)
-	     nil)))))
+	    `(comment "//" ,comment nil)
+	    nil)
+	))))
  
 (defmacro decompose-type (item)
   "Decompose type like declaration but without name"

--- a/src/cxx/syntax.lisp
+++ b/src/cxx/syntax.lisp
@@ -62,25 +62,29 @@
   "Decompose initializer list and instantiate nodes / quite like declaration item"
   (multiple-value-bind (specifier type id init initializer-list-p comment)
       (decompose-declaration item)
-    `(declaration-item
-      ;; set specifiers
-      ,(when specifier
-	 `(specifier
-	   (make-nodelist ,specifier)))
-      ;; set type
-      (type (make-node ,type))
-      ;; set identifier
-      (make-node ,id)
-      ;; set value
-      ,(if init 
-	   (if initializer-list-p
-	       `(declaration-list-initializer (make-nodelist ,init))
-	       `(declaration-value (make-node ,init)))
-	   nil)
-      ;; set comment
-      ,(if comment
-	   `(comment "//" ,comment nil)
-	   nil))))
+    `(values
+      (declaration-item
+       ;; set specifiers
+       ,(when specifier
+	  `(specifier
+	    (make-nodelist ,specifier)))
+       ;; set type
+       (type (make-node ,type))
+       ;; set identifier
+       (make-node ,id)
+       ;; set value
+       ,(if init 
+	    (if initializer-list-p
+		`(declaration-list-initializer (make-nodelist ,init))
+		`(declaration-value (make-node ,init)))
+	    nil)
+       ;; set comment
+       ;;,(if comment
+       ;;	    `(comment "//" ,comment nil)
+       ;;	    nil))
+       nil)
+      ,(if comment `(comment "//" ,comment nil))
+      )))
 
 (c++syntax decl (bindings &body body)
   "Declare variables"

--- a/src/cxx/syntax.lisp
+++ b/src/cxx/syntax.lisp
@@ -77,14 +77,8 @@
 	    (if initializer-list-p
 		`(declaration-list-initializer (make-nodelist ,init))
 		`(declaration-value (make-node ,init)))
-	    nil)
-       ;; set comment
-       ;;,(if comment
-       ;;	    `(comment "//" ,comment nil)
-       ;;	    nil))
-       nil)
-      ,(if comment `(comment "//" ,comment nil))
-      )))
+	    nil))
+      ,@(if comment `((comment "//" ,comment nil))))))
 
 (c++syntax decl (bindings &body body)
   "Declare variables"

--- a/src/cxx/syntax.lisp
+++ b/src/cxx/syntax.lisp
@@ -24,36 +24,49 @@
     (make-node ,(second item))))
 
 (defun decompose-declaration (item)
-  "Decompose initializer list / quite like declaration item. The last
+  "Decompose initializer list / quite like declaration item. The butlast
    value returnd specifies if the declaration actually used an
    initializer list or not."
   ;; check if initialization is present
-  (let ((val (first (last item))))
-    (if (and (listp val)
-	     (eql (length val) 1)
-	     (listp (car val))
-	     (eql (length (car val)) 1)
-	     (listp (caar val)))
-	;; decompose arg list with list initializer
-	(let ((spec+type+id (butlast item))
-	      (inits        (caar val)))
-	  (let ((specifier (butlast spec+type+id 2))
-		(type+id   (last    spec+type+id 2)))
-	    (values specifier (first type+id) (second type+id) inits t)))
+  (labels ((penultimate (list) ;; second-last item in LIST
+	     (first (last (butlast list))))
+	   (suffix-is (str list) ;; check if LIST ends with (... STR something)
+	     (let ((symbol (penultimate list)))
+	       (and (symbolp symbol)
+		    (equal (symbol-name symbol) str)))))
 
-	;; pass to standard declaration decomposition
-	(multiple-value-bind (spec type name init) (cm-c:decompose-declaration item)
-	  (values spec type name init nil)))))
+    ;; transparently remove comment from ITEM
+    (multiple-value-bind (comment item)
+	(if (suffix-is "comment" item)
+	    (values (butlast item) (butlast item 2))
+	    (values nil item))
+
+      (let ((val (first (last item))))
+	(if (and (listp val)
+		 (eql (length val) 1)
+		 (listp (car val))
+		 (eql (length (car val)) 1)
+		 (listp (caar val)))
+	    ;; decompose arg list with list initializer
+	    (let ((spec+type+id (butlast item))
+		  (inits        (caar val)))
+	      (let ((specifier (butlast spec+type+id 2))
+		    (type+id   (last    spec+type+id 2)))
+		(values specifier (first type+id) (second type+id) inits t comment)))
+
+	    ;; pass to standard declaration decomposition
+	    (multiple-value-bind (spec type name init comment) (cm-c:decompose-declaration item)
+	      (values spec type name init nil comment)))))))
 
 (defmacro make-declaration-node/with-list-initializer (item)
   "Decompose initializer list and instantiate nodes / quite like declaration item"
-   (multiple-value-bind (specifier type id init initializer-list-p)
-       (decompose-declaration item)
+  (multiple-value-bind (specifier type id init initializer-list-p comment)
+      (decompose-declaration item)
     `(declaration-item
       ;; set specifiers
       ,(when specifier
-	     `(specifier
-	       (make-nodelist ,specifier)))
+	 `(specifier
+	   (make-nodelist ,specifier)))
       ;; set type
       (type (make-node ,type))
       ;; set identifier
@@ -63,6 +76,10 @@
 	   (if initializer-list-p
 	       `(declaration-list-initializer (make-nodelist ,init))
 	       `(declaration-value (make-node ,init)))
+	   nil)
+      ;; set comment
+      ,(if comment
+	   `(comment "//" ,comment nil)
 	   nil))))
 
 (c++syntax decl (bindings &body body)


### PR DESCRIPTION
I only added support for this for `cm-c` and `cm-cxx`. If you feel that the changes are alright, then I'll fix the others.

I mainly want to get your input on the pretty printer code. The outline is:
- While writing the subnodes of `declaration-item`s, the traverser will not emit comments
- When the `declaration-item` is done and has a comment field, the comment is emitted after the `;`

My main question is: is there a better way to do this? because getting the comment node itself and accessing the pretty printer was quite fiddely.