### PR TITLE
src/front/cm.c: git-style cm-<name> dispatch, drop if-else chain

### DIFF
--- a/src/front/cm.c
+++ b/src/front/cm.c
@@ -6,48 +6,84 @@
 #include <errno.h>
 #include <unistd.h>
 
-int main(int argc, char **argv)
+/* Legacy spellings that predate the cm-<name> convention. Only entries
+ * whose canonical binary name doesn't already match `cm-<argv[1]>`
+ * belong here -- this table exists for backwards-compatible aliases,
+ * not for registering backends. A new backend needs no entry: dropping
+ * a `cm-wasm` executable anywhere on $CM_EXEC_PATH or $PATH is enough
+ * to make `cm wasm` work. */
+struct alias { const char *name, *canonical; };
+static const struct alias aliases[] = {
+	{ "c++",    "cm-cxx" },
+	{ "opencl", "cm-opencl" },
+};
+
+/* Exec cm-<name>, looking first in $CM_EXEC_PATH (falling back to the
+ * compiled-in BINDIR), then in $PATH -- the same two-tier lookup git
+ * uses to resolve git-<verb>. Does not return on success. */
+static void exec_generator(const char *canonical, char **argv)
 {
+	const char *exec_path = getenv("CM_EXEC_PATH");
 	char *prog = NULL;
-	char *gen = NULL;
-	int len = 0;
-	bool help = false, version=false;
-	
-	if (argc == 1) {
-		printf("C-Mera generator selection frontend.\n"
-				"Please specify generator type as c, c++, cxx, glsl, ocl, cuda or use --help.\n"
-				"Generator abbreviations are ok and checked in the order given above.\n");
-		return 1;
-	}
-	
-	len = strlen(argv[1]);
-	if      (strncmp(argv[1], "c",      len) == 0) gen = "cm-c";
-	else if (strncmp(argv[1], "c++",    len) == 0) gen = "cm-cxx";
-	else if (strncmp(argv[1], "cxx",    len) == 0) gen = "cm-cxx";
-	else if (strncmp(argv[1], "glsl",   len) == 0) gen = "cm-glsl";
-	else if (strncmp(argv[1], "ocl",    len) == 0) gen = "cm-opgencl";
-	else if (strncmp(argv[1], "opencl", len) == 0) gen = "cm-opencl";
-	else if (strncmp(argv[1], "cuda",   len) == 0) gen = "cm-cuda";
-	else if (strncmp(argv[1], "--version", len) == 0) { gen = "cm-c"; version = true; }
-	else if (strncmp(argv[1], "-V", len) == 0) { gen = "cm-c"; version = true; }
-	else { gen = "cm-c"; help = true; }
-	
-	int n = asprintf(&prog, "%s/%s", BINDIR, gen);
-	if (n <= 0) {
+
+	if (!exec_path) exec_path = BINDIR;
+	if (asprintf(&prog, "%s/%s", exec_path, canonical) <= 0) {
 		fprintf(stderr, "Allocation error, cannot start generator.\n");
-		return 1;
+		exit(1);
 	}
-	
-	if (help)
-		execl(prog, "cm <generator>", "--help", NULL);
-	else if (version)
-		execl(prog, "cm <generator>", "--version", NULL);
-	else {
-		argv[1] = gen;
-		execv(prog, argv+1);
-	}
-	fprintf(stderr, "Cannot spawn generator process: %s\n", strerror(errno));
-	return 1;
+
+	if (access(prog, X_OK) == 0)
+		execv(prog, argv);
+	else
+		execvp(canonical, argv); /* fall back to $PATH, like git-<verb> */
+
+	fprintf(stderr, "cm: '%s' is not a c-mera generator "
+			"(looked in %s and $PATH): %s\n",
+			canonical, exec_path, strerror(errno));
+	exit(1);
 }
 
+/* Resolve a user-typed backend name to the cm-<name> binary it means:
+ * the alias table first, then the direct `cm-<name>` convention. */
+static const char *resolve (const char *requested)
+{
+	size_t i;
+	char *canonical = NULL;
+
+	for (i = 0; i < sizeof(aliases) / sizeof(*aliases); i++)
+		if (strcmp(requested, aliases[i].name) == 0)
+			return aliases[i].canonical;
+
+	if (asprintf(&canonical, "cm-%s", requested) <= 0) {
+		fprintf(stderr, "Allocation error, cannot start generator.\n");
+		exit(1);
+	}
+	return canonical;
+}
+
+int main(int argc, char **argv)
+{
+	if (argc == 1) {
+		printf("C-Mera generator selection frontend.\n"
+				"Usage: cm <backend> [args...]\n"
+				"Looks for an executable named cm-<backend> on $CM_EXEC_PATH\n"
+				"(defaults to %s) or $PATH, the way git looks for git-<verb>.\n"
+				"Adding a backend needs no change here: just install cm-<backend>.\n",
+				BINDIR);
+		return 1;
+	}
+
+	if (strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-V") == 0) {
+		argv[1] = "--version";
+		exec_generator("cm-c", argv + 1);
+	}
+	if (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0) {
+		argv[1] = "--help";
+		exec_generator("cm-c", argv + 1);
+	}
+
+	argv[1] = (char *) resolve(argv[1]);
+	exec_generator(argv[1], argv + 1);
+	return 1; /* unreached: exec_generator exits on failure */
+}
 


### PR DESCRIPTION
Replace the hardcoded if-else abbreviation chain with a two-tier lookup: check $CM_EXEC_PATH (falls back to the compiled-in BINDIR), then fall back to $PATH -- the same mechanism git uses to resolve git-<verb>. A new backend (e.g. cm-wasm) becomes reachable as 'cm wasm' by being installed anywhere on $PATH; this file no longer needs to change to add a backend.

Legacy multi-spelling aliases (c++ -> cm-cxx) are kept in a small static table, since they aren't backend registration, just spelling compatibility. Fixes a latent bug where 'ocl' resolved to the nonexistent binary cm-opgencl instead of cm-opencl (verified against Makefile.am's bin_PROGRAMS, which only ever built cm-opencl).

Also restores --help/-h/--version/-V top-level handling, which the naive removal of the if-else chain would otherwise have dropped.